### PR TITLE
Add deepcopy methods for LarkCompletionEngine and StreamingCSD

### DIFF
--- a/synchromesh/completion_engine.py
+++ b/synchromesh/completion_engine.py
@@ -14,6 +14,8 @@ class CompletionEngine:
 
 class LarkCompletionEngine(CompletionEngine):
     def __init__(self, grammar, start_token, allow_ws: bool = True):
+        self.grammar = grammar
+        self.start_token = start_token
         self.parser = Lark(grammar, start=start_token, parser='lalr',
                            regex=True)
         self.terminal_dict = self.parser._terminals_dict
@@ -38,6 +40,13 @@ class LarkCompletionEngine(CompletionEngine):
             valid_regex.append("\\s+")
 
         return regex.compile('|'.join(valid_regex))
+
+    def __deepcopy__(self, memo):
+        return LarkCompletionEngine(
+            grammar=self.grammar,
+            start_token=self.start_token,
+            allow_ws=self.allow_ws
+        )
 
 
 def main():

--- a/synchromesh/synchromesh.py
+++ b/synchromesh/synchromesh.py
@@ -87,7 +87,6 @@ class StreamingCSD:
             lm_vocabulary=deepcopy(self._vocab),
             enforce_token_maximality=deepcopy(self.enforce_token_maximality)
         )
-        # TODO: copy the trie?
         for t in self._prefix_tokens:
             csd.feed_prediction(t)
         return csd

--- a/synchromesh/synchromesh.py
+++ b/synchromesh/synchromesh.py
@@ -3,6 +3,7 @@
 import os
 import regex
 import time
+from copy import deepcopy
 
 from .completion_engine import CompletionEngine, LarkCompletionEngine
 from .language_model import LanguageModel, RandomLanguageModel, OpenAIModel, HuggingFaceModel
@@ -40,6 +41,7 @@ class StreamingCSD:
         self._completion_engine = completion_engine
         self._completion_points: dict[str, regex.Pattern] = {}
         self._completion_points[''] = completion_engine.complete('')
+        self.enforce_token_maximality = enforce_token_maximality
 
         self.init_stream()
 
@@ -78,6 +80,18 @@ class StreamingCSD:
             if len(v) > 1:
                 break
             self.feed_prediction(v[0])
+
+    def __deepcopy__(self, memo):
+        csd = StreamingCSD(
+            completion_engine=deepcopy(self._completion_engine),
+            lm_vocabulary=deepcopy(self._vocab),
+            enforce_token_maximality=deepcopy(self.enforce_token_maximality)
+        )
+        # TODO: copy the trie?
+        for t in self._prefix_tokens:
+            csd.feed_prediction(t)
+        return csd
+
 
 
 # Implements the Constrained Semantic Decoding algorithm.


### PR DESCRIPTION
Implements `__deepcopy__` methods for `LarkCompletionEngine` and `StreamingCSD`. The ability to deepcopy these classes is needed to support SMC Steering with Synchromesh. Specifically, this will support the ability to clone particles while maintaining separate `StreamingCSD` states for each.

Reference implementation: https://github.com/probcomp/hfppl/blob/gg/grammar_constrained_smc/examples/grammar_constraint.py

Please let me know if this PR looks reasonable!